### PR TITLE
fix: include query strings in URL matching for expression filters

### DIFF
--- a/src/libs.js
+++ b/src/libs.js
@@ -23,7 +23,7 @@ export const spliceWWW = (url) => {
 	let newURL;
 	try {
 		let urlObject = new URL(url);
-		newURL = `${urlObject.hostname}${urlObject.pathname}`;
+		newURL = `${urlObject.hostname}${urlObject.pathname}${urlObject.search}`;
 		// Strip "www." if the URL starts with it.
 		newURL = newURL.replace(/^www[a-z0-9]?\./, "");
 	} catch (error) {

--- a/src/redux/Reducers.js
+++ b/src/redux/Reducers.js
@@ -15,9 +15,9 @@ import initialState from "./initialState.json";
 // *     returns 2: '\*RRRING\* Hello\?'
 // *     example 3: preg_quote("\\.+*?[^]$(){}=!<>|:");
 // *     returns 3: '\\\.\+\*\?\[\^\]\$\(\)\{\}\=\!\<\>\|\:'
-const preg_quote = (str, delimiter) => (`${str}`).replace(new RegExp(`[.\\\\+*?\\[\\^\\]$(){}=!<>|:\\${delimiter || ""}-]`, "g"), "\\$&");
+const preg_quote = (str, delimiter) => (`${str}`).replace(new RegExp(`[.\\\\+*?\\[\\^\\]$(){}!<>|:\\${delimiter || ""}-]`, "g"), "\\$&");
 
-const globStringToRegex = (str) => `^${preg_quote(str).replace(/\\\*/g, ".*").replace(/\\\?/g, ".")}$`;
+const globStringToRegex = (str) => `^${preg_quote(str).replace(/\\\*/g, ".*")}$`;
 
 const hasExpression = (state, action) => state.some((expression) => expression.expression === action.payload.expression);
 export const expression = (state = {}, action) => {

--- a/src/ui/popup/App.js
+++ b/src/ui/popup/App.js
@@ -69,7 +69,7 @@ class App extends Component {
 						<img style={{
 							height: "1em", width: "1em", margin: "0 5px 0px 13px"
 						}} src={tab.favIconUrl} />
-						<span>{splicedURL}</span>
+						<span>{hostname}</span>
 					</div>
 
 				</div>


### PR DESCRIPTION
- Add urlObject.search to spliceWWW() to preserve query parameters
- Remove unnecessary escaping of = in preg_quote regex
- Keep ? literal in glob-to-regex conversion (not as single-char wildcard)
- Display hostname only in popup Host Website label